### PR TITLE
chore(devops): group all dependencies into single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
     "config:recommended",
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
-    ":dependencyDashboard"
+    ":dependencyDashboard",
+    "group:all"
   ],
   "labels": ["dependencies"],
   "vulnerabilityAlerts": {
@@ -12,15 +13,15 @@
   },
   "packageRules": [
     {
-      "matchDepTypes": ["devDependencies"],
-      "groupName": "all devDependencies",
-      "automerge": true,
-      "automergeStrategy": "squash"
-    },
-    {
       "matchPackageNames": ["pnpm"],
       "enabled": false
+    },
+    {
+      "groupName": "all dependencies",
+      "matchPackagePatterns": ["*"]
     }
   ],
+  "separateMajorMinor": false,
+  "separateMinorPatch": false,
   "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## Summary
Update Renovate configuration to combine ALL dependency updates into a single PR.

## Problem
Current configuration creates multiple separate PRs:
- chore(deps): update all devdependencies
- chore(deps): update actions/setup-node action to v6
- chore(deps): update actions/cache action to v5
- ... (too many PRs)

## Solution
Group everything into ONE PR:
- Add `group:all` preset
- Add catch-all package rule
- Disable major/minor/patch separation
- Remove automerge (manual merge)

## Changes
```diff
+ "group:all"
+ {
+   "groupName": "all dependencies",
+   "matchPackagePatterns": ["*"]
+ }
+ "separateMajorMinor": false
+ "separateMinorPatch": false
- automerge: true (removed)
```

## Result
✅ Single PR with all updates:
- npm packages (devDependencies)
- GitHub Actions
- Major/Minor/Patch versions combined

## How to Use
1. Check Dependency Dashboard
2. Check "all dependencies" checkbox
3. ONE PR created with everything
4. Review and merge manually

---
**Related**: Previous PR #43 (initial Renovate setup)