### PR TITLE
ci: add automated build and commit workflow

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - main
     paths:
       - '.dev/src/**'
       - '.dev/public/**'
@@ -39,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: 'lts/*'
 
       - name: Enable Corepack and use latest pnpm
         run: |


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to automatically build frontend assets when source files change.

## Problem
Currently, developers need to manually run `pnpm build` after modifying source files and commit the generated assets. This is error-prone and often forgotten.

## Solution
Automated workflow that:
1. Triggers on push to `.dev/**`
2. Uses corepack with latest pnpm
3. Installs dependencies
4. Builds frontend
5. Commits changes if build outputs differ

## Workflow Details

### Trigger Conditions
```yaml
on:
  push:
    branches: [master, main]
    paths:
      - '.dev/**'                    # Source files changed
      - '!htdocs/**'                 # Ignore build outputs
      - '!.github/workflows/**'      # Ignore workflow changes
```

### Anti Infinite-Loop Measures
1. **paths-ignore**: Build outputs (`htdocs/`) don't trigger workflow
2. **Commit message check**: Skips if `[build]` in last commit message
3. **Build tag**: Generated commits include `[build]` tag

### Steps
1. Setup Node.js 20
2. `corepack use pnpm@latest`
3. `pnpm install`
4. `pnpm build`
5. Check for changes in `htdocs/`
6. Commit and push with standard message:
```
build: regenerate frontend assets [build]

Compile latest frontend changes:
- CSS: htdocs/luci-static/aurora/main.css
- JS: htdocs/luci-static/resources/

Generated from .dev/ source files.
```

## Example Workflow
```bash
# Developer pushes changes to .dev/src/media/main.css
→ Workflow triggers
→ Builds project
→ Detects changes in htdocs/luci-static/aurora/main.css
→ Commits with [build] tag
→ Pushes to same branch
# No manual build step needed!
```

## Testing
1. Modify any file in `.dev/src/`
2. Push to master
3. Workflow runs automatically
4. Build assets committed if changed

---
**Note**: This PR includes synced fork with upstream