### PR TITLE
chore(devops): add scheduled dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
   "vulnerabilityAlerts": {
     "labels": ["security"]
   },
+  "schedule": [
+    "before 9am on monday"
+  ],
+  "timezone": "Asia/Shanghai",
   "packageRules": [
     {
       "matchPackageNames": ["pnpm"],


### PR DESCRIPTION
## Summary
Add automatic schedule for Renovate dependency updates.

## Changes
- Schedule: every Monday before 9am (Asia/Shanghai timezone)

## Behavior
- Auto-creates PR every Monday, no Dashboard needed
- Security alerts still immediate
- Dashboard still available for manual trigger

---
Fork synced with upstream