### PR TITLE
perf: inline font-face CSS and preload the active sans woff2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Aurora Theme (A modern browser theme built with Vite and Tailwind CSS)
 LUCI_DEPENDS:=+luci-base
 
-PKG_VERSION:=1.0.15
+PKG_VERSION:=1.0.16
 PKG_RELEASE:=20260711
 PKG_LICENSE:=Apache-2.0
 

--- a/ucode/template/themes/aurora/header.ut
+++ b/ucode/template/themes/aurora/header.ut
@@ -46,13 +46,15 @@
 	const toolbar_enabled = tokens.toolbar_enabled ? tokens.toolbar_enabled == '1' : true;
 	const icon_cache_version = tokens.icon_cache_version || '0';
 	const font_css = readfile(`/www${media}/fonts/aurora-font.css`);
-	let font_preload = trim(readfile(`/www${media}/fonts/preload.txt`) ?? '');
-	if (index(font_preload, '/luci-static/aurora/fonts/') != 0)
+	const preload_raw = readfile(`/www${media}/fonts/preload.txt`);
+	// null = file absent (older config app): fall back to Lato below.
+	// '' = deliberately empty (pure-stack preset): preload nothing.
+	let font_preload = preload_raw == null ? null : trim(preload_raw);
+	if (font_preload && index(font_preload, '/luci-static/aurora/fonts/') != 0)
 		font_preload = '';
-	// preload.txt absent (fresh install / older config app): the default
-	// combined CSS only declares Lato, preload it directly.
-	if (!font_preload && font_css && index(font_css, 'lato-v24-latin-regular') >= 0)
-		font_preload = `${media}/fonts/lato-v24-latin-regular.woff2`;
+	if (font_preload == null)
+		font_preload = (font_css && index(font_css, 'lato-v24-latin-regular') >= 0)
+			? `${media}/fonts/lato-v24-latin-regular.woff2` : '';
 	const logo_svg = tokens.logo_svg || 'logo.svg';
 	const favicon_png = tokens.favicon_png || '';
 	const favicon_ico = tokens.favicon_ico || 'favicon.ico';

--- a/ucode/template/themes/aurora/header.ut
+++ b/ucode/template/themes/aurora/header.ut
@@ -12,7 +12,7 @@
 {%
 	import { getuid, getspnam } from 'luci.core';
 	import { cursor } from 'uci';
-	import { lsdir } from 'fs';
+	import { lsdir, readfile } from 'fs';
 
 	const boardinfo = ubus.call('system', 'board') ?? {};
 	const hostname = striptags(boardinfo.hostname ?? '?');
@@ -45,6 +45,14 @@
 	const nav_type = tokens.nav_type || 'mega-menu';
 	const toolbar_enabled = tokens.toolbar_enabled ? tokens.toolbar_enabled == '1' : true;
 	const icon_cache_version = tokens.icon_cache_version || '0';
+	const font_css = readfile(`/www${media}/fonts/aurora-font.css`);
+	let font_preload = trim(readfile(`/www${media}/fonts/preload.txt`) ?? '');
+	if (index(font_preload, '/luci-static/aurora/fonts/') != 0)
+		font_preload = '';
+	// preload.txt absent (fresh install / older config app): the default
+	// combined CSS only declares Lato, preload it directly.
+	if (!font_preload && font_css && index(font_css, 'lato-v24-latin-regular') >= 0)
+		font_preload = `${media}/fonts/lato-v24-latin-regular.woff2`;
 	const logo_svg = tokens.logo_svg || 'logo.svg';
 	const favicon_png = tokens.favicon_png || '';
 	const favicon_ico = tokens.favicon_ico || 'favicon.ico';
@@ -170,7 +178,14 @@
 		<link rel="stylesheet" href="{{ media }}/patches/{{ patch }}.css">
 		{% endfor %}
 		{% endif %}
+		{% if (font_preload): %}
+		<link rel="preload" as="font" type="font/woff2" crossorigin href="{{ font_preload }}?v={{ icon_cache_version }}">
+		{% endif %}
+		{% if (font_css): %}
+		<style>{{ font_css }}</style>
+		{% else %}
 		<link rel="stylesheet" href="{{ media }}/fonts/aurora-font.css?v={{ icon_cache_version }}">
+		{% endif %}
 		<link rel="icon" href="{{ media }}/images/{{ logo_svg }}?v={{ icon_cache_version }}" sizes="any" type="image/svg+xml">
 		{% if (favicon_png): %}
 		<link rel="icon" href="{{ media }}/images/{{ favicon_png }}?v={{ icon_cache_version }}" type="image/png">

--- a/ucode/template/themes/aurora/header.ut
+++ b/ucode/template/themes/aurora/header.ut
@@ -179,7 +179,7 @@
 		{% endfor %}
 		{% endif %}
 		{% if (font_preload): %}
-		<link rel="preload" as="font" type="font/woff2" crossorigin href="{{ font_preload }}?v={{ icon_cache_version }}">
+		<link rel="preload" as="font" type="font/woff2" crossorigin href="{{ font_preload }}">
 		{% endif %}
 		{% if (font_css): %}
 		<style>{{ font_css }}</style>

--- a/ucode/template/themes/aurora/header.ut
+++ b/ucode/template/themes/aurora/header.ut
@@ -185,8 +185,6 @@
 		{% endif %}
 		{% if (font_css): %}
 		<style>{{ font_css }}</style>
-		{% else %}
-		<link rel="stylesheet" href="{{ media }}/fonts/aurora-font.css?v={{ icon_cache_version }}">
 		{% endif %}
 		<link rel="icon" href="{{ media }}/images/{{ logo_svg }}?v={{ icon_cache_version }}" sizes="any" type="image/svg+xml">
 		{% if (favicon_png): %}


### PR DESCRIPTION
## Summary

Companion to eamonxg/luci-app-aurora-config#16 (font system v2).

- Replace the render-blocking `<link rel="stylesheet" .../aurora-font.css>` with the CSS inlined into a `<style>` tag via ucode `readfile` — zero extra request on the critical path. The old stylesheet fallback was dropped as dead code: it pointed at the same file `readfile` just failed to read, and a missing font CSS simply falls back to the system stacks.
- Emit `<link rel="preload" as="font" crossorigin>` for the active sans woff2 from `fonts/preload.txt` (written by the config app). The href is passed through verbatim so it byte-matches the URL inside the inlined @font-face. Marker-file states: absent (older config app → Lato fallback), deliberately empty (pure system stack → no preload), path (preload it), garbage (ignore).
- Upgrades from the v1 font pipeline are covered on the config-app side: its `uci-defaults` migration regenerates `aurora-font.css` (dropping the old remote `@import` fallback) before this template inlines it, so the zero-external-requests guarantee holds across the upgrade window too.

Router cost: one small local `readfile` per render replaces a full uhttpd HTTP request — net cheaper. PKG_VERSION 1.0.16.

Verified on-device: served HTML carries the inline @font-face + matching preload; no render-blocking font request; `document.fonts.load` confirms the webfont renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)